### PR TITLE
correct xcode complains about taking the address of a temp object

### DIFF
--- a/src/dpx.cpp
+++ b/src/dpx.cpp
@@ -364,8 +364,11 @@ operator<< (std::ostream& out, DpxReader& io) {
     
     // file
     if(defined(io.header().file.magic_number))
+    {
+        u32_dpx magic = io.header().file.magic_number;
         out << "- dpx:file.magic_number: "
-            << (char*)&io.header().file.magic_number << std::endl;
+            << (char*)&magic << std::endl;
+    }
     if(defined(io.header().file.offset))
         out << "- dpx:file.offset: "
             << io.header().file.offset << std::endl;


### PR DESCRIPTION
Original DPX code does not compile with clang/Xcode on macOS.

clang does not accept taking the address of a temporary variable.